### PR TITLE
Fix getopt parameters

### DIFF
--- a/waybar-updates
+++ b/waybar-updates
@@ -16,7 +16,7 @@ packages_limit=10
 devel=false
 notify=false
 
-PARSED_ARGUMENTS=$(getopt -o "hi:c:l:d" --long "help,interval:,cycles:,packages-limit:,devel" --name "waybar-updates" -- "$@")
+PARSED_ARGUMENTS=$(getopt -o "hi:c:l:dn" --long "help,interval:,cycles:,packages-limit:,devel,notify" --name "waybar-updates" -- "$@")
 eval set -- "$PARSED_ARGUMENTS"
 while :; do
   case "$1" in
@@ -38,7 +38,7 @@ while :; do
     ;;
   -n | --notify)
     notify=true
-    shift 2
+    shift
     ;;
   -h | --help) usage ;;
   --)

--- a/waybar-updates
+++ b/waybar-updates
@@ -16,7 +16,7 @@ packages_limit=10
 devel=false
 notify=false
 
-PARSED_ARGUMENTS=$(getopt -o "hi:c:l:d::" --long "help,interval,cycles,packages-limit,devel::" --name "waybar-updates" -- "$@")
+PARSED_ARGUMENTS=$(getopt -o "hi:c:l:d" --long "help,interval:,cycles:,packages-limit:,devel" --name "waybar-updates" -- "$@")
 eval set -- "$PARSED_ARGUMENTS"
 while :; do
   case "$1" in
@@ -34,7 +34,7 @@ while :; do
     ;;
   -d | --devel)
     devel=true
-    shift 2
+    shift
     ;;
   -n | --notify)
     notify=true


### PR DESCRIPTION
The parameters passed to `getopt` have a few discrepancies which can cause unexpected behaviour depending on which args are passed.

* **Long-format `--interval`, `--cycles` and `--packages-limit`:**
  Missing the `:` meant only the short options would receive the value
* **Short `-d` and long-format `--devel` args**:
  Redundant `::` for a flag that takes no value (mostly harmless)

The `-n`/`--notify` flag was also missing, which combined with `shift 2` meant a command like `waybar-updates -n -d` would eat the `-d`.