### PR TITLE
Add support for custom formats with labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 Tiny Waybar module to check Arch Linux updates from official repositories and AUR.
 
 ## Features
-- Sends notifications about updates.
+- Sends (optional) notifications about updates.
 - Supports GNU gettext localization (contribute new po-files!)
+- Support for [custom formats](#formatting) to show only the numbers you want.
 - Checks updates from AUR using Aurweb RPC, so works independently.
 - Can check for development packages upstream changes (see -d [options](#command-line-options))
 - Shows updates in the tooltip.
@@ -26,7 +27,7 @@ Tiny Waybar module to check Arch Linux updates from official repositories and AU
 - curl
 - jq
 - libnotify
-- git (if using --devel [option](#command-line-options))
+- git (if using `--devel` [option](#command-line-options))
 
 ## Usage
 
@@ -78,11 +79,26 @@ to use localization and don't want to store them in `/usr/share/locale`.
 
 ### Command-line options
 The following options are available:
-- `-i, --interval`: Interval between checks (default: 6 seconds)
-- `-c, --cycles`: Cycles between online checks (e.g. 6s * 600 cycles = 3600s = 1h between online checks) (default: 600 cycles)
-- `-l, --packages-limit`: Maximum number of packages to be shown in notifications and tooltip (default: 10)
-- `-d, --devel`: Also check for development packages upstream changes (default:disabled)
-- `-n , --notify`: Turns on notifications for updates.
+| Option | Value | Default | Description |
+|--------|-------|---------|-------------|
+| `-f`, `--format` | `string` | `{total}` | Custom format used for main output text (see [Formatting](#formatting)) |
+| `-t`, `--tooltip` | `string` |  | Custom tooltip format (see [Formatting](#formatting)) |
+| `-i`, `--interval` | `int` | `6` | Interval (in seconds) between checks |
+| `-c`, `--cycles` | `int` | `600` | Cycles between online checks (e.g. 6s *interval* * 600 *cycles* = 3600s = 1h) |
+| `-l`, `--packages-limit` | `int` | `10` | Maximum number of packages to be shown in notifications and tooltip |
+| `-d`, `--devel` | `none` | `off` | Also check for upstream changes in development packages |
+| `-n`, `--notify` | `none` | `off` | Turns on notifications for updates |
+
+#### Formatting
+
+The tooltip and main text formatters can both use "labels" to format their output.
+
+In `--tooltip`, the `{}` label will be replaced with the package list. In `--format`, it's an alias for `{total}`.
+
+Supported custom count labels are `{aur}`, `{dev}`, `{pacman}` and `{total}`. These labels support a custom prefix and/or suffix which can be used to define icons, for example `{A :aur:\n}`, however keep in mind:
+* Values **must** be separated with a colon (`:`)
+* Values **may** contain newlines and tabs (`\n`, `\r` and `\t`)
+* Values **cannot** contain braces (`{` or `}`), 
 
 
 ## Localization

--- a/waybar-updates
+++ b/waybar-updates
@@ -2,6 +2,7 @@
 
 usage() {
   echo "Usage: waybar-updates [options]
+    -f, --format          Custom format string with one/more of {aur}, {pacman} or {total}
     -i, --interval        Interval between checks
     -c, --cycles          Cycles between online checks (e.g. 6s * 600 cycles = 3600s = 1h between online checks)
     -l, --packages-limit  Maximum number of packages to be shown in notifications and tooltip
@@ -16,10 +17,14 @@ packages_limit=10
 devel=false
 notify=false
 
-PARSED_ARGUMENTS=$(getopt -o "hi:c:l:dn" --long "help,interval:,cycles:,packages-limit:,devel,notify" --name "waybar-updates" -- "$@")
+PARSED_ARGUMENTS=$(getopt -o "hf:i:c:l:dn" --long "help,format:,interval:,cycles:,packages-limit:,devel,notify" --name "waybar-updates" -- "$@")
 eval set -- "$PARSED_ARGUMENTS"
 while :; do
   case "$1" in
+  -f | --format)
+    format="$2"
+    shift 2
+    ;;
   -i | --interval)
     interval="$2"
     shift 2
@@ -164,8 +169,16 @@ function check_updates() {
 }
 
 function json() {
+  local output=$1
+
+  if [[ -n "$1" && -n "$format" ]]; then
+    output="${format/{aur\}/$aur_updates_count}"
+    output="${output/{pacman\}/$pacman_updates_count}"
+    output="${output/{total\}/$total_updates_count}"
+  fi
+
   jq --unbuffered --null-input --compact-output \
-    --arg text "$1" \
+    --arg text "$output" \
     --arg alt "$2" \
     --arg tooltip "$3" \
     --arg class "$4" \

--- a/waybar-updates
+++ b/waybar-updates
@@ -11,6 +11,7 @@ usage() {
   exit 2
 }
 
+format="{total}"
 interval=6
 cycles_number=600
 packages_limit=10
@@ -168,17 +169,22 @@ function check_updates() {
   fi
 }
 
+format_output() {
+  local aur_label pacman_label total_label
+
+  [ "$aur_updates_count" -gt 0 ] && aur_label="\2${aur_updates_count}\4"
+  [ "$pacman_updates_count" -gt 0 ] && pacman_label="\2${pacman_updates_count}\4"
+  [ "$total_updates_count" -gt 0 ] && total_label="\2${total_updates_count}\4"
+
+  echo -n "$format" | tr '\n' '\r' | sed \
+    -e 's/{\(\([^{]\+\):\)\?aur\(:\([^}]\+\)\)\?}/'"$aur_label"'/' \
+    -e 's/{\(\([^{]\+\):\)\?pacman\(:\([^}]\+\)\)\?}/'"$pacman_label"'/' \
+    -e 's/{\(\([^{]\+\):\)\?total\(:\([^}]\+\)\)\?}/'"$total_label"'/'
+}
+
 function json() {
-  local output=$1
-
-  if [[ -n "$1" && -n "$format" ]]; then
-    output="${format/{aur\}/$aur_updates_count}"
-    output="${output/{pacman\}/$pacman_updates_count}"
-    output="${output/{total\}/$total_updates_count}"
-  fi
-
   jq --unbuffered --null-input --compact-output \
-    --arg text "$output" \
+    --arg text "$1" \
     --arg alt "$2" \
     --arg tooltip "$3" \
     --arg class "$4" \
@@ -280,7 +286,7 @@ while true; do
     fi
   fi
   if [ "$total_updates_count" -gt 0 ]; then
-    json $total_updates_count "pending-updates" "$(echo -e "$tooltip" | head -n "$packages_limit")" "pending-updates"
+    json "$(format_output)" "pending-updates" "$(echo -e "$tooltip" | head -n "$packages_limit")" "pending-updates"
   else
     json "" "updated" "$(gettext "waybar-updates" "System is up to date")" "updated"
   fi

--- a/waybar-updates
+++ b/waybar-updates
@@ -12,8 +12,8 @@ usage() {
   exit 2
 }
 
-format="{total}"
-tooltip_format="{ :pacman: }{  :aur: }{  :dev}\n\n{}"
+text_format="{total}"
+tooltip_format="\t\t {\t  :pacman}{\t  :aur}{\t  :dev}\n\n{}"
 interval=6
 cycles_number=600
 packages_limit=10
@@ -26,7 +26,7 @@ eval set -- "$PARSED_ARGUMENTS"
 while :; do
   case "$1" in
   -f | --format)
-    format="$2"
+    text_format="$2"
     shift 2
     ;;
   -t | --tooltip)
@@ -65,7 +65,7 @@ while :; do
   esac
 done
 
-function check_pacman_updates() {
+check_pacman_updates() {
   if [ "$1" == "online" ]; then
     pacman_updates=$(checkupdates --nocolor)
   elif [ "$1" == "offline" ]; then
@@ -76,7 +76,7 @@ function check_pacman_updates() {
   pacman_updates_count=$(echo "$pacman_updates" | grep -vc ^$)
 }
 
-function check_devel_updates() {
+check_devel_updates() {
   ignored_packages=$(pacman-conf IgnorePkg)
   if [ "$1" == "online" ]; then
     develsuffixes="git"
@@ -104,7 +104,7 @@ function check_devel_updates() {
   devel_updates_count=$(echo "$devel_updates" | grep -vc ^$)
 }
 
-function build_devel_list() {
+build_devel_list() {
   custom_pkgbuild_vars="_gitname=\|_githubuser=\|_githubrepo=\|_gitcommit=\|url=\|_pkgname=\|_gitdir=\|_repo_name=\|_gitpkgname=\|source_dir=\|_name="
 
   truncate -s 0 "$tmp_devel_packages_file"
@@ -130,7 +130,7 @@ function build_devel_list() {
   done <<< "$1"
 }
 
-function check_aur_updates() {
+check_aur_updates() {
   ignored_packages=$(pacman-conf IgnorePkg)
   if [ -n "$ignored_packages" ]; then
       old_aur_packages=$(pacman -Qm | grep -vF "$ignored_packages")
@@ -159,7 +159,7 @@ function check_aur_updates() {
   aur_updates_count=$(echo "$aur_updates" | grep -vc ^$)
 }
 
-function check_updates() {
+check_updates() {
   if [ "$1" == "online" ]; then
     check_pacman_updates online
     check_aur_updates online
@@ -176,41 +176,50 @@ function check_updates() {
   fi
 }
 
-format_output() {
-  local aur_label dev_label pacman_label total_label
+format() {
+  local text format_arg="${1}_format" aur_label dev_label pacman_label total_label
 
   [ "$aur_updates_count" -gt 0 ] && aur_label="\2${aur_updates_count}\4"
   [ "$devel_updates_count" -gt 0 ] && dev_label="\2${devel_updates_count}\4"
   [ "$pacman_updates_count" -gt 0 ] && pacman_label="\2${pacman_updates_count}\4"
   [ "$total_updates_count" -gt 0 ] && total_label="\2${total_updates_count}\4"
 
-  echo -n "$format" | tr '\n' '\r' | sed \
-    -e 's/{\(\([^{]\+\):\)\?aur\(:\([^}]\+\)\)\?}/'"$aur_label"'/' \
-    -e 's/{\(\([^{]\+\):\)\?dev\(:\([^}]\+\)\)\?}/'"$dev_label"'/' \
-    -e 's/{\(\([^{]\+\):\)\?pacman\(:\([^}]\+\)\)\?}/'"$pacman_label"'/' \
-    -e 's/{\(\([^{]\+\):\)\?total\(:\([^}]\+\)\)\?}/'"$total_label"'/'
-}
-
-format_tooltip() {
-  local aur_label dev_label list pacman_label total_label content="$tooltip_format"
-
-  [ "$aur_updates_count" -gt 0 ] && aur_label="\2${aur_updates_count}\4"
-  [ "$devel_updates_count" -gt 0 ] && dev_label="\2${devel_updates_count}\4"
-  [ "$pacman_updates_count" -gt 0 ] && pacman_label="\2${pacman_updates_count}\4"
-  [ "$total_updates_count" -gt 0 ] && total_label="\2${total_updates_count}\4"
-
-  list="$(echo -e "$tooltip" | head -n "$packages_limit")"
-  content="$(echo -n "$tooltip_format" | tr '\n' '\r' | sed \
+  text="$(echo -n "${!format_arg}" | tr '\n' '\r' | sed \
     -e 's/{\(\([^{]\+\):\)\?aur\(:\([^}]\+\)\)\?}/'"$aur_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?dev\(:\([^}]\+\)\)\?}/'"$dev_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?pacman\(:\([^}]\+\)\)\?}/'"$pacman_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?total\(:\([^}]\+\)\)\?}/'"$total_label"'/' \
   )"
 
-  echo -e "${content//{\}/$list}"
+  echo -e "${text//{\}/$2}"
 }
 
-function json() {
+send_output() {
+  local source status=pending-updates text tooltip
+
+  if [[ ! $total_updates_count -gt 0 ]]; then
+    json "" updated "$(gettext "waybar-updates" "System is up to date")" updated
+    return
+  fi
+
+  for source in pacman aur devel; do
+    tooltip_append "${source}_updates_count" "${source}_updates"
+  done
+
+  json "$(format text "$total_updates_count")" "$status" "$(format \
+    tooltip "$(echo -e "$tooltip" | head -n "$packages_limit")" \
+  )" "$status"
+}
+
+tooltip_append() {
+  [[ ${!1} -gt 0 ]] || return
+
+  [[ -z $tooltip ]] || tooltip+="\n"
+
+  tooltip+="${!2}"
+}
+
+json() {
   jq --unbuffered --null-input --compact-output \
     --arg text "$1" \
     --arg alt "$2" \
@@ -219,14 +228,14 @@ function json() {
     '{"text": $text, "alt": $alt, "tooltip": $tooltip, "class": $class}'
 }
 
-function cleanup() {
+cleanup() {
   echo "Cleaning up..."
   rm -f "$tmp_aur_packages_file"
   rm -f "$tmp_devel_packages_file"
   exit 0
 }
 
-function sendNotification() {
+send_notification() {
   if ! $notify; then
     return;
   fi
@@ -275,49 +284,30 @@ while true; do
 
   # send pushes, limit the body by 10 packages;
   # also create message that will be used as tooltip
-  tooltip=""
   if [ "$pacman_updates_count" -gt 0 ]; then
     template=$(ngettext "waybar-updates" "%d update available from pacman" "%d updates available from pacman" "$pacman_updates_count")
     # shellcheck disable=SC2059
-    sendNotification -a waybar-updates -u normal -i software-update-available-symbolic \
+    send_notification -a waybar-updates -u normal -i software-update-available-symbolic \
       "$(printf "$template" "$pacman_updates_count")" \
       "$(echo "$pacman_updates" | head -n "$packages_limit")"
-
-    tooltip+="$pacman_updates"
   fi
   if [ "$aur_updates_count" -gt 0 ]; then
     template=$(ngettext "waybar-updates" "%d update available from AUR" "%d updates available from AUR" "$aur_updates_count")
     # shellcheck disable=SC2059
-    sendNotification -a waybar-updates -u normal -i software-update-available-symbolic \
+    send_notification -a waybar-updates -u normal -i software-update-available-symbolic \
       "$(printf "$template" "$aur_updates_count")" \
       "$(echo "$aur_updates" | head -n "$packages_limit")"
-
-    if [ -z "$tooltip" ]; then
-      tooltip+="$aur_updates"
-    else
-      tooltip+="\n$aur_updates"
-    fi
   fi
   if [ $devel == true ];then
     if [ "$devel_updates_count" -gt 0 ]; then
       template=$(ngettext "waybar-updates" "%d devel-update available from AUR" "%d devel-updates available from AUR" "$devel_updates_count")
       # shellcheck disable=SC2059
-      sendNotification -a waybar-updates -u normal -i software-update-available-symbolic \
+      send_notification -a waybar-updates -u normal -i software-update-available-symbolic \
         "$(printf "$template" "$devel_updates_count")" \
         "$(echo "$devel_updates" | head -n "$packages_limit")"
-
-      if [ -z "$tooltip" ]; then
-        tooltip+="$devel_updates"
-      else
-        tooltip+="\n$devel_updates"
-      fi
     fi
   fi
-  if [ "$total_updates_count" -gt 0 ]; then
-    json "$(format_output)" "pending-updates" "$(format_tooltip)" "pending-updates"
-  else
-    json "" "updated" "$(gettext "waybar-updates" "System is up to date")" "updated"
-  fi
 
+  send_output
   sleep "$interval"
 done

--- a/waybar-updates
+++ b/waybar-updates
@@ -194,12 +194,24 @@ format() {
   echo -e "${text//{\}/$2}"
 }
 
+send_notification() {
+  local count="$3" list="$4" source="$2" text type="$1"
+  local fmt="%d ${type} available from ${source}"
+
+  [[ $notify == true && $count -gt 0 ]] || return
+
+  text="$(ngettext waybar-updates "$fmt" "${fmt/update/updates}" "$count")"
+
+  notify-send -a waybar-updates -u normal -i software-update-available-symbolic \
+    "${text//%d/$count}" "$(echo "$list" | head -n "$packages_limit")"
+}
+
 send_output() {
   local source status=pending-updates text tooltip
 
   if [[ ! $total_updates_count -gt 0 ]]; then
     json "" updated "$(gettext "waybar-updates" "System is up to date")" updated
-    return
+    return 1
   fi
 
   for source in pacman aur devel; do
@@ -233,13 +245,6 @@ cleanup() {
   rm -f "$tmp_aur_packages_file"
   rm -f "$tmp_devel_packages_file"
   exit 0
-}
-
-send_notification() {
-  if ! $notify; then
-    return;
-  fi
-  notify-send "$@"
 }
 
 # sync at the first start
@@ -282,32 +287,12 @@ while true; do
     continue
   fi
 
-  # send pushes, limit the body by 10 packages;
-  # also create message that will be used as tooltip
-  if [ "$pacman_updates_count" -gt 0 ]; then
-    template=$(ngettext "waybar-updates" "%d update available from pacman" "%d updates available from pacman" "$pacman_updates_count")
-    # shellcheck disable=SC2059
-    send_notification -a waybar-updates -u normal -i software-update-available-symbolic \
-      "$(printf "$template" "$pacman_updates_count")" \
-      "$(echo "$pacman_updates" | head -n "$packages_limit")"
-  fi
-  if [ "$aur_updates_count" -gt 0 ]; then
-    template=$(ngettext "waybar-updates" "%d update available from AUR" "%d updates available from AUR" "$aur_updates_count")
-    # shellcheck disable=SC2059
-    send_notification -a waybar-updates -u normal -i software-update-available-symbolic \
-      "$(printf "$template" "$aur_updates_count")" \
-      "$(echo "$aur_updates" | head -n "$packages_limit")"
-  fi
-  if [ $devel == true ];then
-    if [ "$devel_updates_count" -gt 0 ]; then
-      template=$(ngettext "waybar-updates" "%d devel-update available from AUR" "%d devel-updates available from AUR" "$devel_updates_count")
-      # shellcheck disable=SC2059
-      send_notification -a waybar-updates -u normal -i software-update-available-symbolic \
-        "$(printf "$template" "$devel_updates_count")" \
-        "$(echo "$devel_updates" | head -n "$packages_limit")"
-    fi
-  fi
+  # Output text and tooltip then send push notifcations, limiting the body to 10 packages;
+  send_output && {
+    send_notification update pacman "$pacman_updates_count" "$pacman_updates"
+    send_notification update AUR "$aur_updates_count" "$aur_updates"
+    send_notification devel-update AUR "$devel_updates_count" "$devel_updates"
+  }
 
-  send_output
   sleep "$interval"
 done

--- a/waybar-updates
+++ b/waybar-updates
@@ -13,7 +13,7 @@ usage() {
 }
 
 format="{total}"
-tooltip_format="{ :pacman: }{  :aur: }\n\n{}"
+tooltip_format="{ :pacman: }{  :aur: }{  :dev}\n\n{}"
 interval=6
 cycles_number=600
 packages_limit=10
@@ -177,28 +177,32 @@ function check_updates() {
 }
 
 format_output() {
-  local aur_label pacman_label total_label
+  local aur_label dev_label pacman_label total_label
 
   [ "$aur_updates_count" -gt 0 ] && aur_label="\2${aur_updates_count}\4"
+  [ "$devel_updates_count" -gt 0 ] && dev_label="\2${devel_updates_count}\4"
   [ "$pacman_updates_count" -gt 0 ] && pacman_label="\2${pacman_updates_count}\4"
   [ "$total_updates_count" -gt 0 ] && total_label="\2${total_updates_count}\4"
 
   echo -n "$format" | tr '\n' '\r' | sed \
     -e 's/{\(\([^{]\+\):\)\?aur\(:\([^}]\+\)\)\?}/'"$aur_label"'/' \
+    -e 's/{\(\([^{]\+\):\)\?dev\(:\([^}]\+\)\)\?}/'"$dev_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?pacman\(:\([^}]\+\)\)\?}/'"$pacman_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?total\(:\([^}]\+\)\)\?}/'"$total_label"'/'
 }
 
 format_tooltip() {
-  local aur_label list pacman_label total_label content="$tooltip_format"
+  local aur_label dev_label list pacman_label total_label content="$tooltip_format"
 
   [ "$aur_updates_count" -gt 0 ] && aur_label="\2${aur_updates_count}\4"
+  [ "$devel_updates_count" -gt 0 ] && dev_label="\2${devel_updates_count}\4"
   [ "$pacman_updates_count" -gt 0 ] && pacman_label="\2${pacman_updates_count}\4"
   [ "$total_updates_count" -gt 0 ] && total_label="\2${total_updates_count}\4"
 
   list="$(echo -e "$tooltip" | head -n "$packages_limit")"
   content="$(echo -n "$tooltip_format" | tr '\n' '\r' | sed \
     -e 's/{\(\([^{]\+\):\)\?aur\(:\([^}]\+\)\)\?}/'"$aur_label"'/' \
+    -e 's/{\(\([^{]\+\):\)\?dev\(:\([^}]\+\)\)\?}/'"$dev_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?pacman\(:\([^}]\+\)\)\?}/'"$pacman_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?total\(:\([^}]\+\)\)\?}/'"$total_label"'/' \
   )"

--- a/waybar-updates
+++ b/waybar-updates
@@ -12,8 +12,10 @@ usage() {
   exit 2
 }
 
-text_format="{total}"
-tooltip_format="\t\t {\t  :pacman}{\t  :aur}{\t  :dev}\n\n{}"
+declare -A formats=()
+formats[text]="{total}"
+formats[tooltip]="\t\t {\t  :pacman}{\t  :aur}{\t  :dev}\n\n{}"
+
 interval=6
 cycles_number=600
 packages_limit=10
@@ -26,11 +28,11 @@ eval set -- "$PARSED_ARGUMENTS"
 while :; do
   case "$1" in
   -f | --format)
-    text_format="$2"
+    formats[text]="$2"
     shift 2
     ;;
   -t | --tooltip)
-    tooltip_format="$2"
+    formats[tooltip]="$2"
     shift 2
     ;;
   -i | --interval)
@@ -177,14 +179,14 @@ check_updates() {
 }
 
 format() {
-  local text format_arg="${1}_format" aur_label dev_label pacman_label total_label
+  local text format_arg="${formats[$1]}" aur_label dev_label pacman_label total_label
 
   [ "$aur_updates_count" -gt 0 ] && aur_label="\2${aur_updates_count}\4"
   [ "$devel_updates_count" -gt 0 ] && dev_label="\2${devel_updates_count}\4"
   [ "$pacman_updates_count" -gt 0 ] && pacman_label="\2${pacman_updates_count}\4"
   [ "$total_updates_count" -gt 0 ] && total_label="\2${total_updates_count}\4"
 
-  text="$(echo -n "${!format_arg}" | tr '\n' '\r' | sed \
+  text="$(echo -n "${format_arg}" | tr '\n' '\r' | sed \
     -e 's/{\(\([^{]\+\):\)\?aur\(:\([^}]\+\)\)\?}/'"$aur_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?dev\(:\([^}]\+\)\)\?}/'"$dev_label"'/' \
     -e 's/{\(\([^{]\+\):\)\?pacman\(:\([^}]\+\)\)\?}/'"$pacman_label"'/' \

--- a/waybar-updates
+++ b/waybar-updates
@@ -3,6 +3,7 @@
 usage() {
   echo "Usage: waybar-updates [options]
     -f, --format          Custom format string with one/more of {aur}, {pacman} or {total}
+    -t, --tooltip         Custom format string for the tooltip (use {} for the update list)
     -i, --interval        Interval between checks
     -c, --cycles          Cycles between online checks (e.g. 6s * 600 cycles = 3600s = 1h between online checks)
     -l, --packages-limit  Maximum number of packages to be shown in notifications and tooltip
@@ -12,18 +13,24 @@ usage() {
 }
 
 format="{total}"
+tooltip_format="{ :pacman: }{  :aur: }\n\n{}"
 interval=6
 cycles_number=600
 packages_limit=10
 devel=false
 notify=false
 
-PARSED_ARGUMENTS=$(getopt -o "hf:i:c:l:dn" --long "help,format:,interval:,cycles:,packages-limit:,devel,notify" --name "waybar-updates" -- "$@")
+PARSED_ARGUMENTS=$(getopt --name "waybar-updates" -o "hf:t:i:c:l:dn" --long \
+  "help,format:,tooltip:,interval:,cycles:,packages-limit:,devel,notify" -- "$@")
 eval set -- "$PARSED_ARGUMENTS"
 while :; do
   case "$1" in
   -f | --format)
     format="$2"
+    shift 2
+    ;;
+  -t | --tooltip)
+    tooltip_format="$2"
     shift 2
     ;;
   -i | --interval)
@@ -182,6 +189,23 @@ format_output() {
     -e 's/{\(\([^{]\+\):\)\?total\(:\([^}]\+\)\)\?}/'"$total_label"'/'
 }
 
+format_tooltip() {
+  local aur_label list pacman_label total_label content="$tooltip_format"
+
+  [ "$aur_updates_count" -gt 0 ] && aur_label="\2${aur_updates_count}\4"
+  [ "$pacman_updates_count" -gt 0 ] && pacman_label="\2${pacman_updates_count}\4"
+  [ "$total_updates_count" -gt 0 ] && total_label="\2${total_updates_count}\4"
+
+  list="$(echo -e "$tooltip" | head -n "$packages_limit")"
+  content="$(echo -n "$tooltip_format" | tr '\n' '\r' | sed \
+    -e 's/{\(\([^{]\+\):\)\?aur\(:\([^}]\+\)\)\?}/'"$aur_label"'/' \
+    -e 's/{\(\([^{]\+\):\)\?pacman\(:\([^}]\+\)\)\?}/'"$pacman_label"'/' \
+    -e 's/{\(\([^{]\+\):\)\?total\(:\([^}]\+\)\)\?}/'"$total_label"'/' \
+  )"
+
+  echo -e "${content//{\}/$list}"
+}
+
 function json() {
   jq --unbuffered --null-input --compact-output \
     --arg text "$1" \
@@ -286,7 +310,7 @@ while true; do
     fi
   fi
   if [ "$total_updates_count" -gt 0 ]; then
-    json "$(format_output)" "pending-updates" "$(echo -e "$tooltip" | head -n "$packages_limit")" "pending-updates"
+    json "$(format_output)" "pending-updates" "$(format_tooltip)" "pending-updates"
   else
     json "" "updated" "$(gettext "waybar-updates" "System is up to date")" "updated"
   fi


### PR DESCRIPTION
Hi! I started switching to Waybar at the weekend and found this to replace what I had for Polybar previously. It works great—thanks for merging #29 so quickly btw—but ideally ***I'd like to show counts separately***.

I couldn't find a way to get Waybar passing anything from the "real" `format` option in the bar config, so instead I've hacked together some basic "label" parsing. It supports a custom prefix/suffix (separated by `:`) which allows for per-count auto-hiding icons, but at the cost of a *really* ugly sed block.


## New CLI args
* `-f, --format`
* `-t, --tooltip`

## Supported Labels
* `{aur}`
* `{dev}`
* `{pacman}`
* `{total}`

## Examples

### New defaults

```
"exec": "waybar-updates",

// All examples are based on this:
"format": "{icon}{}",
"format-icons": {
    "pending-updates": " ",
    "updated": ""
}
```

![wbu-0-default](https://github.com/user-attachments/assets/3e59be7c-e319-4d6f-91ca-e1aeb6c5fd44)


### Custom prefix and suffix

```
"exec": "waybar-updates --format '{total}{ (+:aur: AUR)}'",
```

![wbu-1-text](https://github.com/user-attachments/assets/65bd7985-abe3-405c-87a6-ab0e2a74adfd)


### Multiline Pacman+AUR example with icons

```
"exec": "waybar-updates -df '{ :pacman:\n  }{ :aur}'",
```

![wbu-2-multiline](https://github.com/user-attachments/assets/0f414200-d40b-41fc-805c-e5c73186020b)


### Showing only package counts in the tooltip

```
"exec": "waybar-updates --tooltip '{ :pacman}{  :aur}{  :dev}'",
```

![wbu-3-simplett](https://github.com/user-attachments/assets/19fa95d0-56fc-4c76-99e9-540b5e8a36a9)


### Showing all counts individually (and hiding them in the tooltip)

```
"exec": "waybar-updates -df '{pacman}{  :aur} {  :dev}' -t '{}'",
```

![wbu-4-countsinbar](https://github.com/user-attachments/assets/3b4a43fe-f5d0-4cd0-934e-a0fbea984397)